### PR TITLE
Fixed "if 'translate' in transform: TypeError: argument of type 'None…

### DIFF
--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -450,7 +450,7 @@ def get_commands(translate, group, precise=False, raise_error=False, truncate_co
                 group_stroke_width = int(filter( lambda x: x in '0123456789.', group_stroke_width))
                 group_stroke_width = group_stroke_width if group_stroke_width >= 1 else 1
               #handle the transform in the layer group
-              transform = child.get('transform')
+              transform = child.get('transform', dict())
               if 'translate' in transform:
                 translate_strs = re.search(r'(?:translate\()(.*)\s(.*)\)',transform).group(1,2)
                 translate = (translate[0] + float(translate_strs[0]), translate[1] + float(translate_strs[1]))


### PR DESCRIPTION
Running svg2pdc as per Usage instructions fails with the following error

$ python tools/svg2pdc.py resources/Pebble_50x50_Sunny_day.svg 
Traceback (most recent call last):
  File "tools/svg2pdc.py", line 636, in <module>
    main(args)
  File "tools/svg2pdc.py", line 611, in main
    args.precise)
  File "tools/svg2pdc.py", line 579, in create_pdc_from_path
    size, commands, error = parse_svg_image(path, precise, raise_error)
  File "tools/svg2pdc.py", line 539, in parse_svg_image
    cmd_list, error = get_commands(translate, root, precise, raise_error)
  File "tools/svg2pdc.py", line 454, in get_commands
    if 'translate' in transform:
TypeError: argument of type 'NoneType' is not iterable
$ 
