### PR TITLE
Add support for building pdc sequence from xml animation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .lock-*
+*.pyc

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -554,26 +554,30 @@ def parse_svg_image(filename, precise=False, raise_error=False):
 def parse_sequence_file(filename):
     '''
     <?xml version="1.0" encoding="UTF-8"?>
-    <sequence>
-      <frame src="frames/01.svg" duration="33" />
-      <frame src="frames/02.svg" duration="33" />
+    <sequence default_duration="33" >
+      <frame src="frames/01.svg" />
+      <frame src="frames/02.svg" />
       <frame src="frames/03.svg" duration="99" />
-      <frame src="frames/02.svg" duration="33" />
-      <frame src="frames/01.svg" duration="33" />
+      <frame src="frames/02.svg" />
+      <frame src="frames/01.svg" />
     </sequence>
     '''
     sequence_root = get_xml(filename)
     frames_desc = []
-    for frame_desc in sequence_root:
-        try:
-            src = os.path.dirname(filename) + '/' + str(frame_desc.get('src'))
-            duration = int(frame_desc.get('duration'))
-            if os.path.isfile(src):
-                frames_desc.append({'src': src, 'duration': duration})
-            else:
-	        raise ValueError
-        except (TypeError, ValueError):
-            print 'Invalid frame definition: ' + src
+    try:
+        default_duration = sequence_root.get('default_duration')
+        for frame_desc in sequence_root:
+            try:
+                src = os.path.dirname(filename) + '/' + str(frame_desc.get('src'))
+                duration = int(frame_desc.get('duration')) if frame_desc.get('duration') else int(default_duration)
+                if os.path.isfile(src):
+                    frames_desc.append({'src': src, 'duration': duration})
+                else:
+                    raise ValueError
+            except (TypeError, ValueError):
+                print 'Invalid frame definition: ' + src
+    except (TypeError, ValueError):
+        print 'Invalid sequence file'
     return frames_desc
 
 

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -551,7 +551,7 @@ def parse_svg_image(filename, precise=False, raise_error=False):
     return size, cmd_list, error
 
 
-def parse_sequence_file(filename):
+def parse_sequence_file(filename, duration_fallback=False):
     '''
     <?xml version="1.0" encoding="UTF-8"?>
     <sequence default_duration="33" >
@@ -569,7 +569,12 @@ def parse_sequence_file(filename):
         for frame_desc in sequence_root:
             try:
                 src = os.path.dirname(filename) + '/' + str(frame_desc.get('src'))
-                duration = int(frame_desc.get('duration')) if frame_desc.get('duration') else int(default_duration)
+                if frame_desc.get('duration'):
+                    duration = int(frame_desc.get('duration'))
+                elif default_duration:
+                    duration = int(default_duration)
+                else:
+                    duration = int(duration_fallback)
                 if os.path.isfile(src):
                     frames_desc.append({'src': src, 'duration': duration})
                 else:
@@ -597,10 +602,10 @@ def parse_svg_sequence_dir(dir_name, duration, precise=False, raise_error=False)
     return size, frames, error_files
 
 
-def parse_svg_sequence_file(filename, precise=False, raise_error=False):
+def parse_svg_sequence_file(filename, duration_fallback=False, precise=False, raise_error=False):
     frames = []
     error_files = []
-    frames_desc = parse_sequence_file(filename)
+    frames_desc = parse_sequence_file(filename, duration_fallback)
     for frame_desc in frames_desc:
         size, cmd_list, error = parse_svg_image(frame_desc['src'], precise, raise_error)
         if cmd_list:
@@ -623,7 +628,7 @@ def create_pdc_from_path(path, sequence, out_path, verbose, duration, play_count
         commands = []
         if sequence:
             if os.path.isfile(path):
-                result = parse_svg_sequence_file(path, precise, raise_error)
+                result = parse_svg_sequence_file(path, duration, precise, raise_error)
             else:
                 result = parse_svg_sequence_dir(dir_name, duration, precise, raise_error)
             if result:

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -565,9 +565,15 @@ def parse_sequence_file(filename):
     sequence_root = get_xml(filename)
     frames_desc = []
     for frame_desc in sequence_root:
-        src = os.path.dirname(filename) + '/' + frame_desc.get('src')
-        duration = int(frame_desc.get('duration'))
-        frames_desc.append({'src': src, 'duration': duration})
+        try:
+            src = os.path.dirname(filename) + '/' + str(frame_desc.get('src'))
+            duration = int(frame_desc.get('duration'))
+            if os.path.isfile(src):
+                frames_desc.append({'src': src, 'duration': duration})
+            else:
+	        raise ValueError
+        except (TypeError, ValueError):
+            print 'Invalid frame definition: ' + src
     return frames_desc
 
 

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # Copyright (c) 2015 Pebble Technology
 #

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -559,7 +559,7 @@ def parse_svg_sequence(dir_name, precise=False, raise_error=False):
     translate, size = get_info(get_xml(file_list[0]))  # get the viewbox from the first file
     for filename in file_list:
         cmd_list, error = get_commands(translate, get_xml(filename), precise, raise_error)
-        if cmd_list is not None:
+        if cmd_list:
             frames.append(cmd_list)
         if error:
             error_files.append(filename)

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -591,7 +591,9 @@ def parse_svg_sequence(sequence_frames, precise=False, raise_error=False):
     frames = []
     error_files = []
     for sequence_frame in sequence_frames:
-        size, cmd_list, error = parse_svg_image(sequence_frame['src'], precise, raise_error)
+        image_size, cmd_list, error = parse_svg_image(sequence_frame['src'], precise, raise_error)
+        if size == (0, 0): # get the viewbox from the first frame
+	    size = image_size
         if cmd_list:
             frames.append({'command_list': cmd_list, 'duration': sequence_frame['duration']})
         if error:

--- a/tools/svg2pdc.py
+++ b/tools/svg2pdc.py
@@ -586,33 +586,30 @@ def parse_sequence_file(filename, duration_fallback=False):
     return frames_desc
 
 
-def parse_svg_sequence_dir(dir_name, duration, precise=False, raise_error=False):
+def parse_svg_sequence(sequence_frames, precise=False, raise_error=False):
+    size = (0, 0)
     frames = []
     error_files = []
-    file_list = sorted(glob.glob(dir_name + "/*.svg"))
-    if not file_list:
-        return
-    translate, size = get_info(get_xml(file_list[0]))  # get the viewbox from the first file
-    for filename in file_list:
-        cmd_list, error = get_commands(translate, get_xml(filename), precise, raise_error)
+    for sequence_frame in sequence_frames:
+        size, cmd_list, error = parse_svg_image(sequence_frame['src'], precise, raise_error)
         if cmd_list:
-            frames.append({'command_list': cmd_list, 'duration': duration})
+            frames.append({'command_list': cmd_list, 'duration': sequence_frame['duration']})
         if error:
             error_files.append(filename)
     return size, frames, error_files
+
+
+def parse_svg_sequence_dir(dir_name, duration, precise=False, raise_error=False):
+    sequence_frames = []
+    file_list = sorted(glob.glob(dir_name + "/*.svg"))
+    for filename in file_list:
+        sequence_frames.append({'src': filename, 'duration': duration})
+    return parse_svg_sequence(sequence_frames, precise, raise_error)
 
 
 def parse_svg_sequence_file(filename, duration_fallback=False, precise=False, raise_error=False):
-    frames = []
-    error_files = []
-    frames_desc = parse_sequence_file(filename, duration_fallback)
-    for frame_desc in frames_desc:
-        size, cmd_list, error = parse_svg_image(frame_desc['src'], precise, raise_error)
-        if cmd_list:
-            frames.append({'command_list': cmd_list, 'duration': frame_desc['duration']})
-        if error:
-            error_files.append(filename)
-    return size, frames, error_files
+    sequence_frames = parse_sequence_file(filename, duration_fallback)
+    return parse_svg_sequence(sequence_frames, precise, raise_error)
 
 
 def create_pdc_from_path(path, sequence, out_path, verbose, duration, play_count, precise=False, raise_error=False):


### PR DESCRIPTION
Previously #8 (new branch on my fork)

It is now possible to create a pdc sequence based on definition of the animation in a xml file

The format of the xml file is _inspired_ by the one used by apngasm
https://github.com/apngasm/apngasm/blob/master/resources/images/test.xml
which I was using previously in my project
Here is an example of such a file now for pdc
https://github.com/tardypad/pebble-watchface-amsterdam/blob/master/resources/animations/slide/chalk/animation.xml
I've put an example in the code as well as a reference

The benefits of this feature are:
- avoid duplication of svg frames in a folder
- possibility to specify different durations per frame

I've added that feature without breaking the previous behavior of the svg2pdc tool
So for example it's still possible to use the sequence building with a folder path

There is as well a couple of tiny changes / fixes in the first commits
Let me know if you want me to split the pull request
